### PR TITLE
Params validation and url escape for email

### DIFF
--- a/mailgun.lua
+++ b/mailgun.lua
@@ -1,4 +1,5 @@
 local M = {}
+local socket_url = require("socket.url")
 
 -- Project: Mailgun 0.11
 -- Description: Send email with mailgun.com API
@@ -18,6 +19,7 @@ mailgun.send({
 })
 --]]
 
+M.isInitialized = false
 local debug = false
 local sandboxID
 local apiKey
@@ -29,31 +31,47 @@ local defaultText
 local defaultCallback
 
 function M.init(params)
+  M.isInitialized = false
   local params = params or {}
 
   -- sandbox id and api key from mailgun console
-  sandboxID = params.sandboxID or "sandboxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-  apiKey = params.apiKey or "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXXXX-XXXXXXXX"
+  if (type(params.sandboxID) ~= "string") then
+    print("warning: mailgun plugin failed to initialize. 'sandboxID' parameter is required. You can find it at mailgun dashboard")
+    return
+  end
+
+  if (type(params.apiKey) ~= "string") then
+    print("warning: mailgun plugin failed to initialize. 'apiKey' parameter is required")
+    return
+  end
+
+  sandboxID = params.sandboxID -- "sandboxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  apiKey = params.apiKey -- "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXXXX-XXXXXXXX"
 
   -- default user email if missing
-  defaultFrom = params.defaultFrom or "crab@test.com" 
+  defaultFrom = params.defaultFrom or "crab@test.com"
   -- recepient email (only confirmed emails are working in sandbox)
-  defaultTo = params.defaultTo or "yourmail@test.com" 
+  defaultTo = params.defaultTo or "yourmail@test.com"
   -- email subject
-  defaultSubject = params.defaultSubject or "Hello, World!" 
+  defaultSubject = params.defaultSubject or "Hello, World!"
   -- email body
-  defaultText = params.defaultText or "This is a test email from Mailgun." 
+  defaultText = params.defaultText or "This is a test email from Mailgun."
   -- debug mode
   debug = params.debug
 
   -- default confirmation callback
-  defaultCallback = params.defaultCallback or function() 
+  defaultCallback = params.defaultCallback or function()
     native.showAlert("Mailgun", "Your message has been sent successfully.", {"Thanks"})
   end
-  
+
+  M.isInitialized = true
 end
 
 function M.send(data)
+  if (not M.isInitialized) then
+    print("warning: mailgun should need to be configured before usage")
+    return
+  end
   native.setActivityIndicator( true )
   local data = data or {}
   local from = data.from or defaultFrom
@@ -67,14 +85,15 @@ function M.send(data)
   local params = {}
   local headers = {}
 
-  local body = ""
-  body = "from="..from
-  body = body.."&to="..to
-  body = body.."&subject="..subject
-  body = body.."&text="..text
+  local body = {
+    "from="..tostring(from),
+    "to="..tostring(to),
+    "subject="..socket_url.escape(subject),
+    "text="..socket_url.escape(text),
+  }
 
   params.headers = headers
-  params.body = body
+  params.body = table.concat(body, "&")
 
   local listener = function(e)
     native.setActivityIndicator( false )
@@ -85,11 +104,14 @@ function M.send(data)
     if e.status == 200 then
       callback()
     else
-      native.showAlert( "Mailgun error", "Error: "..tostring(e.status), {"ok"} )
+      native.showAlert( "Mailgun error", "Error status: "..tostring(e.status) .. "\n" .. tostring(e.response), {"ok"} )
     end
 
   end
 
+  if debug then
+    print("mailgun: sending post request to", to, ", subject = ", subject)
+  end
   network.request( url, "POST", listener, params);
 
 end


### PR DESCRIPTION
1. Plugin now write warning to console if no sandboxID and apiKey are provided
2. Added escaping special characters (now email body sent correctly if you have '&' inside it)